### PR TITLE
Use `zephir` as semantic identifier

### DIFF
--- a/Zephir/Zephir.tmLanguage
+++ b/Zephir/Zephir.tmLanguage
@@ -24,17 +24,17 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.js</string>
+					<string>support.class.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>support.constant.js</string>
+					<string>support.constant.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.js</string>
+					<string>keyword.operator.zephir</string>
 				</dict>
 			</dict>
 		</dict>
@@ -44,42 +44,42 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.js</string>
+					<string>support.class.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>support.constant.js</string>
+					<string>support.constant.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.js</string>
+					<string>keyword.operator.zephir</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.js</string>
+					<string>storage.type.function.zephir</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.begin.js</string>
+					<string>punctuation.definition.parameters.begin.zephir</string>
 				</dict>
 				<key>7</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.function.js</string>
+					<string>variable.parameter.function.zephir</string>
 				</dict>
 				<key>8</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.end.js</string>
+					<string>punctuation.definition.parameters.end.zephir</string>
 				</dict>
 			</dict>
 		</dict>
@@ -89,22 +89,22 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.js</string>
+					<string>support.class.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>support.constant.js</string>
+					<string>support.constant.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.js</string>
+					<string>keyword.operator.zephir</string>
 				</dict>
 			</dict>
 		</dict>
@@ -114,37 +114,37 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.js</string>
+					<string>support.class.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.js</string>
+					<string>keyword.operator.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.js</string>
+					<string>storage.type.function.zephir</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.begin.js</string>
+					<string>punctuation.definition.parameters.begin.zephir</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.function.js</string>
+					<string>variable.parameter.function.zephir</string>
 				</dict>
 				<key>7</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.end.js</string>
+					<string>punctuation.definition.parameters.end.zephir</string>
 				</dict>
 			</dict>
 		</dict>
@@ -154,32 +154,32 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.js</string>
+					<string>keyword.operator.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.js</string>
+					<string>storage.type.function.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.begin.js</string>
+					<string>punctuation.definition.parameters.begin.zephir</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.function.js</string>
+					<string>variable.parameter.function.zephir</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.end.js</string>
+					<string>punctuation.definition.parameters.end.zephir</string>
 				</dict>
 			</dict>
 		</dict>
@@ -189,33 +189,33 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.js</string>
+					<string>storage.type.function.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.begin.js</string>
+					<string>punctuation.definition.parameters.begin.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.function.js</string>
+					<string>variable.parameter.function.zephir</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.end.js</string>
+					<string>punctuation.definition.parameters.end.zephir</string>
 				</dict>
 			</dict>
 			<key>match</key>
 			<string>\b(function)\s+([a-zA-Z_$]\w*)?\s*(\()(.*?)(\))</string>
 			<key>name</key>
-			<string>meta.function.js</string>
+			<string>meta.function.zephir</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -223,33 +223,33 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.js</string>
+					<string>storage.type.function.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.begin.js</string>
+					<string>punctuation.definition.parameters.begin.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.function.js</string>
+					<string>variable.parameter.function.zephir</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.end.js</string>
+					<string>punctuation.definition.parameters.end.zephir</string>
 				</dict>
 			</dict>
 			<key>match</key>
 			<string>\b([a-zA-Z_?.$][\w?.$]*)\s*:\s*\b(function)?\s*(\()(.*?)(\))</string>
 			<key>name</key>
-			<string>meta.function.json.js</string>
+			<string>meta.function.zephiron.zephir</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -257,62 +257,62 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>string.quoted.single.js</string>
+					<string>string.quoted.single.zephir</string>
 				</dict>
 				<key>10</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.begin.js</string>
+					<string>punctuation.definition.parameters.begin.zephir</string>
 				</dict>
 				<key>11</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.function.js</string>
+					<string>variable.parameter.function.zephir</string>
 				</dict>
 				<key>12</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.end.js</string>
+					<string>punctuation.definition.parameters.end.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.begin.js</string>
+					<string>punctuation.definition.string.begin.zephir</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.end.js</string>
+					<string>punctuation.definition.string.end.zephir</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>string.quoted.double.js</string>
+					<string>string.quoted.double.zephir</string>
 				</dict>
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.begin.js</string>
+					<string>punctuation.definition.string.begin.zephir</string>
 				</dict>
 				<key>7</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 				<key>8</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.end.js</string>
+					<string>punctuation.definition.string.end.zephir</string>
 				</dict>
 				<key>9</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>entity.name.function.zephir</string>
 				</dict>
 			</dict>
 			<key>comment</key>
@@ -321,7 +321,7 @@
 			<string>(?:((')([^']*)('))|((")([^"]*)(")))\s*:\s*\b(function)?\s*(\()([^)]*)(\))</string>
 			<!-- <string>(?:((')(.*?)('))|((")(.*?)(")))\s*:\s*\b(function)?\s*(\()(.*?)(\))</string> -->
 			<key>name</key>
-			<string>meta.function.json.js</string>
+			<string>meta.function.zephiron.zephir</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -329,12 +329,12 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.new.js</string>
+					<string>keyword.operator.new.zephir</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.type.instance.js</string>
+					<string>entity.name.type.instance.zephir</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -346,7 +346,7 @@
 			<key>match</key>
 			<string>\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b</string>
 			<key>name</key>
-			<string>constant.numeric.js</string>
+			<string>constant.numeric.zephir</string>
 		</dict>
 		<!--<dict>
 			<key>begin</key>
@@ -356,7 +356,7 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.begin.js</string>
+					<string>punctuation.definition.string.begin.zephir</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -366,18 +366,18 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.end.js</string>
+					<string>punctuation.definition.string.end.zephir</string>
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>storage.type.function.js</string>
+			<string>storage.type.function.zephir</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
 					<string>(\\\\)</string>
 					<key>name</key>
-					<string>constant.character.escape.js</string>
+					<string>constant.character.escape.zephir</string>
 				</dict>
 			</array>
 		</dict>-->
@@ -385,7 +385,7 @@
 			<key>match</key>
 			<string>&lt;([a-zA-Z0-9\_\\]+)&gt;</string>
 			<key>name</key>
-			<string>string.regexp.js</string>
+			<string>string.regexp.zephir</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -395,7 +395,7 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.begin.js</string>
+					<string>punctuation.definition.string.begin.zephir</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -405,18 +405,18 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.end.js</string>
+					<string>punctuation.definition.string.end.zephir</string>
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.quoted.single.js</string>
+			<string>string.quoted.single.zephir</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
 					<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
-					<string>constant.character.escape.js</string>
+					<string>constant.character.escape.zephir</string>
 				</dict>
 			</array>
 		</dict>
@@ -428,7 +428,7 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.begin.js</string>
+					<string>punctuation.definition.string.begin.zephir</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -438,18 +438,18 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.end.js</string>
+					<string>punctuation.definition.string.end.zephir</string>
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.quoted.double.js</string>
+			<string>string.quoted.double.zephir</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
 					<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
-					<string>constant.character.escape.js</string>
+					<string>constant.character.escape.zephir</string>
 				</dict>
 			</array>
 		</dict>
@@ -461,13 +461,13 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.comment.js</string>
+					<string>punctuation.definition.comment.zephir</string>
 				</dict>
 			</dict>
 			<key>end</key>
 			<string>\*/</string>
 			<key>name</key>
-			<string>comment.block.documentation.js</string>
+			<string>comment.block.documentation.zephir</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -477,13 +477,13 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.comment.js</string>
+					<string>punctuation.definition.comment.zephir</string>
 				</dict>
 			</dict>
 			<key>end</key>
 			<string>\*/</string>
 			<key>name</key>
-			<string>comment.block.js</string>
+			<string>comment.block.zephir</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -491,119 +491,119 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.comment.js</string>
+					<string>punctuation.definition.comment.zephir</string>
 				</dict>
 			</dict>
 			<key>match</key>
 			<string>(//).*$\n?</string>
 			<key>name</key>
-			<string>comment.line.double-slash.js</string>
+			<string>comment.line.double-slash.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\b(boolean|string|char|class|resource|object|array|callable|namespace|use|as|get|__toString|set|abstract|double|float|fn|function|int|interface|long|var|void|ulong|uint|uchar|unsigned|self)\b</string>
 			<key>name</key>
-			<string>storage.type.js</string>
+			<string>storage.type.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\b(const|fetch|empty|likely|unlikely|isset|unset|extends|final|implements|private|protected|public|static|scoped|inline|deprecated|enum|throws|clone)\b</string>
 			<key>name</key>
-			<string>storage.modifier.js</string>
+			<string>storage.modifier.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\b(echo|require|break|case|catch|let|continue|default|do|else|elseif|for|goto|if|return|switch|throw|try|while|loop)\b</string>
 			<key>name</key>
-			<string>keyword.control.js</string>
+			<string>keyword.control.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\b(in|reverse|instanceof|new|typeof)\b</string>
 			<key>name</key>
-			<string>keyword.operator.js</string>
+			<string>keyword.operator.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\btrue\b</string>
 			<key>name</key>
-			<string>constant.language.boolean.true.js</string>
+			<string>constant.language.boolean.true.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\bfalse\b</string>
 			<key>name</key>
-			<string>constant.language.boolean.false.js</string>
+			<string>constant.language.boolean.false.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\bnull\b</string>
 			<key>name</key>
-			<string>constant.language.null.js</string>
+			<string>constant.language.null.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\b(parent|self|this)\b</string>
 			<key>name</key>
-			<string>variable.language.js</string>
+			<string>variable.language.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\b(PHP_EOL|PHP_VERSION|([A-Z0-9\_]+))\b</string>
 			<key>name</key>
-			<string>string.regexp.js</string>
+			<string>string.regexp.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>-&gt;|::</string>
 			<key>name</key>
-			<string>keyword.operator.js</string>
+			<string>keyword.operator.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>!|\$|%|&amp;|\*|\-\-|\-|\+\+|\+|~|===|==|=|!=|!==|&lt;=|&gt;=|&lt;&lt;=|&gt;&gt;=|&gt;&gt;&gt;=|&lt;&gt;|&lt;|&gt;|!|&amp;&amp;|\|\||\?\:|\*=|(?&lt;!\()/=|%=|\+=|\-=|&amp;=|\.=|\^=|\b(instanceof|new|typeof|void)\b</string>
 			<key>name</key>
-			<string>keyword.operator.js</string>
+			<string>keyword.operator.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\;</string>
 			<key>name</key>
-			<string>punctuation.terminator.statement.js</string>
+			<string>punctuation.terminator.statement.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>,[ |\t]*</string>
 			<key>name</key>
-			<string>meta.delimiter.object.comma.js</string>
+			<string>meta.delimiter.object.comma.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\.</string>
 			<key>name</key>
-			<string>meta.delimiter.method.period.js</string>
+			<string>meta.delimiter.method.period.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\{|\}</string>
 			<key>name</key>
-			<string>meta.brace.curly.js</string>
+			<string>meta.brace.curly.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\(|\)</string>
 			<key>name</key>
-			<string>meta.brace.round.js</string>
+			<string>meta.brace.round.zephir</string>
 		</dict>
 		<dict>
 			<key>match</key>
 			<string>\[|\]</string>
 			<key>name</key>
-			<string>meta.brace.square.js</string>
+			<string>meta.brace.square.zephir</string>
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js</string>
+	<string>source.php.zephir</string>
 	<key>uuid</key>
 	<string>D757833E-2573-11E3-9CA0-50E7973F7489</string>
 </dict>


### PR DESCRIPTION
In TextMate grammars, it's good style to mark all selectors with semantic identifiers for the language being highlighted.

Since you based off this TM grammar off the Javascript grammar, all the selectors end in `.js`, which is confusing. Even worse, the global `scopeName` is set to `source.js`, which can be an issue when loading the PLIST in many TextMate-compatible parsers.

This PR fixes the semantic identifiers. There should be no visible changes to the highlighting. :)
