### PR TITLE
Make the grammar PCRE compatible

### DIFF
--- a/Zephir/Zephir.tmLanguage
+++ b/Zephir/Zephir.tmLanguage
@@ -381,7 +381,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.zephir</string>
 				</dict>
@@ -414,7 +414,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.zephir</string>
 				</dict>

--- a/Zephir/Zephir.tmLanguage
+++ b/Zephir/Zephir.tmLanguage
@@ -381,7 +381,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.zephir</string>
 				</dict>
@@ -414,7 +414,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
+					<string>\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)</string>
 					<key>name</key>
 					<string>constant.character.escape.zephir</string>
 				</dict>


### PR DESCRIPTION
This pull request changes 1 regular expressions in an attempt to make the grammar PCRE-compatible. While Sublime Text uses an Oniguruma engine, github.com (which rely on this grammar for Zephir highlighting) uses a PCRE-based engine. The two engines interpret `\h` differently, and only Oniguruma engines support implicit count modifiers (`{,n}`).